### PR TITLE
remove unpublished lint packages and disable lint in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           paths:
             - node_modules
 
-      - run: npm run lint
+      # - run: npm run lint
 
       - run:
           name: Jest Tests

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,7 @@
     "jest"
   ],
   "extends": [
-    "semistandard-react",
+    // "semistandard-react",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended"
   ],
@@ -15,7 +15,7 @@
     "@typescript-eslint/no-use-before-define": [
       "error"
     ],
-    "semistandard-react/prop-types": "off"
+    // "semistandard-react/prop-types": "off"
   },
   "settings": {
     "import/extensions": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,10 +51,8 @@
         "@typescript-eslint/eslint-plugin": "^4.15.2",
         "@typescript-eslint/parser": "^4.15.2",
         "eslint": "^7.20.0",
-        "eslint-config-semistandard-react": "^4.2.0",
         "eslint-import-resolver-typescript": "^2.4.0",
         "eslint-plugin-jest": "^24.1.5",
-        "eslint-plugin-semistandard-react": "^4.1.0",
         "jest-when": "^3.2.0",
         "semistandard": "^16.0.0",
         "ts-jest": "^26.5.2"
@@ -6721,12 +6719,6 @@
       "integrity": "sha512-sfV+qNBWKOmF0kZJll1VH5XqOAdTmLlhbOl9WKI11d2eMEe+Kicxnpm24PQWHOqAfk5pAWU2An0LjNCXKa4Usg==",
       "dev": true
     },
-    "node_modules/eslint-config-semistandard-react": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-semistandard-react/-/eslint-config-semistandard-react-4.2.0.tgz",
-      "integrity": "sha512-lSjvk76SWKJSb3M2Ng+3ZRykFyucyfMYbKjI20egeGyWHRyU5xC+vEL5r5FBJcggCq2JBWqbYDnWZtyD8td7Rg==",
-      "dev": true
-    },
     "node_modules/eslint-config-standard": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.0.tgz",
@@ -6961,45 +6953,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
-    "node_modules/eslint-plugin-node": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz",
-      "integrity": "sha512-xhPXrh0Vl/b7870uEbaumb2Q+LxaEcOQ3kS1jtIXanBAwpMre1l5q/l2l/hESYJGEFKuI78bp6Uw50hlpr7B+g==",
-      "dev": true,
-      "dependencies": {
-        "ignore": "^3.3.6",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.3.3",
-        "semver": "5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/ignore": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-      "dev": true
-    },
-    "node_modules/eslint-plugin-node/node_modules/semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/eslint-plugin-promise": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz",
-      "integrity": "sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/eslint-plugin-react": {
       "version": "7.22.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.22.0.tgz",
@@ -7028,25 +6981,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/eslint-plugin-semistandard-react": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-semistandard-react/-/eslint-plugin-semistandard-react-4.1.0.tgz",
-      "integrity": "sha512-mOVb+t00rZrn4Y3k38hre+ONHqe7/ldLvto9WF1SdnAON+/jRDr26H1xVNDuJgveQ4Y7FhhbY05ABWtemylqYw==",
-      "dev": true,
-      "dependencies": {
-        "eslint-plugin-import": "^2.7.0",
-        "eslint-plugin-node": "^5.2.0",
-        "eslint-plugin-promise": "^3.5.0",
-        "eslint-plugin-react": "^7.4.0",
-        "eslint-plugin-standard": "^3.0.1"
-      }
-    },
-    "node_modules/eslint-plugin-standard": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.1.0.tgz",
-      "integrity": "sha512-fVcdyuKRr0EZ4fjWl3c+gp1BANFJD1+RaWa2UPYfMZ6jCtp5RG00kSaXnK/dE5sYzt4kaWJ9qdxqUfc0d9kX0w==",
-      "dev": true
     },
     "node_modules/eslint-plugin-testing-library": {
       "version": "3.10.2",
@@ -25794,12 +25728,6 @@
       "integrity": "sha512-sfV+qNBWKOmF0kZJll1VH5XqOAdTmLlhbOl9WKI11d2eMEe+Kicxnpm24PQWHOqAfk5pAWU2An0LjNCXKa4Usg==",
       "dev": true
     },
-    "eslint-config-semistandard-react": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-semistandard-react/-/eslint-config-semistandard-react-4.2.0.tgz",
-      "integrity": "sha512-lSjvk76SWKJSb3M2Ng+3ZRykFyucyfMYbKjI20egeGyWHRyU5xC+vEL5r5FBJcggCq2JBWqbYDnWZtyD8td7Rg==",
-      "dev": true
-    },
     "eslint-config-standard": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.0.tgz",
@@ -26000,38 +25928,6 @@
         }
       }
     },
-    "eslint-plugin-node": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz",
-      "integrity": "sha512-xhPXrh0Vl/b7870uEbaumb2Q+LxaEcOQ3kS1jtIXanBAwpMre1l5q/l2l/hESYJGEFKuI78bp6Uw50hlpr7B+g==",
-      "dev": true,
-      "requires": {
-        "ignore": "^3.3.6",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.3.3",
-        "semver": "5.3.0"
-      },
-      "dependencies": {
-        "ignore": {
-          "version": "3.3.10",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
-        }
-      }
-    },
-    "eslint-plugin-promise": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz",
-      "integrity": "sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ==",
-      "dev": true
-    },
     "eslint-plugin-react": {
       "version": "7.22.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.22.0.tgz",
@@ -26054,25 +25950,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
       "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ=="
-    },
-    "eslint-plugin-semistandard-react": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-semistandard-react/-/eslint-plugin-semistandard-react-4.1.0.tgz",
-      "integrity": "sha512-mOVb+t00rZrn4Y3k38hre+ONHqe7/ldLvto9WF1SdnAON+/jRDr26H1xVNDuJgveQ4Y7FhhbY05ABWtemylqYw==",
-      "dev": true,
-      "requires": {
-        "eslint-plugin-import": "^2.7.0",
-        "eslint-plugin-node": "^5.2.0",
-        "eslint-plugin-promise": "^3.5.0",
-        "eslint-plugin-react": "^7.4.0",
-        "eslint-plugin-standard": "^3.0.1"
-      }
-    },
-    "eslint-plugin-standard": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.1.0.tgz",
-      "integrity": "sha512-fVcdyuKRr0EZ4fjWl3c+gp1BANFJD1+RaWa2UPYfMZ6jCtp5RG00kSaXnK/dE5sYzt4kaWJ9qdxqUfc0d9kX0w==",
-      "dev": true
     },
     "eslint-plugin-testing-library": {
       "version": "3.10.2",

--- a/package.json
+++ b/package.json
@@ -71,10 +71,8 @@
     "@typescript-eslint/eslint-plugin": "^4.15.2",
     "@typescript-eslint/parser": "^4.15.2",
     "eslint": "^7.20.0",
-    "eslint-config-semistandard-react": "^4.2.0",
     "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-jest": "^24.1.5",
-    "eslint-plugin-semistandard-react": "^4.1.0",
     "jest-when": "^3.2.0",
     "semistandard": "^16.0.0",
     "ts-jest": "^26.5.2"


### PR DESCRIPTION
[ticket](https://trello.com/c/kx7yfp8C/1771-update-lint-configs-and-or-disable-linting-in-ci)

`eslint-config-semistandard-react` and `eslint-plugin-semistandard-react` packages were unpublished from npm this morning. removing them and disabling lint in ci for now, will figure out a new lint config when I get back from vacation